### PR TITLE
Add Drive-based config for Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # aianalyze1
+
+This repository includes a Colab notebook for collecting press release PDFs from the Korean Ministry of Land, Infrastructure and Transport (국토교통부). The notebook downloads PDFs, extracts text, creates embeddings and saves results to Google Drive.
+
+Open `bodo_pdf_colab.ipynb` with Google Colab to run the workflow. The notebook
+expects a JSON configuration file on your Google Drive containing API keys and
+paths. Example `env.json`:
+
+```json
+{
+  "SERVICE_KEY": "YOUR_URL_ENCODED_SERVICE_KEY",
+  "DCLSF_CD": "A00",
+  "START_DATE": "2020-01-01",
+  "END_DATE": "2025-07-08",
+  "PAGE_SIZE": 1000,
+  "DRIVE_DIR": "/content/drive/MyDrive/boan_data",
+  "HF_HOME_DIR": "/content/drive/.hf_cache"
+}
+```
+
+Set `CONFIG_PATH` in the first cell of the notebook to the location of this file
+and the rest of the variables will load automatically.

--- a/bodo_pdf_colab.ipynb
+++ b/bodo_pdf_colab.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aef5a267",
+   "metadata": {},
+   "source": [
+    "# 국토교통부 보도자료 수집/임베딩 노트북\n",
+    "사용 전 첫 번째 셀의 변수를 수정해 주세요."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e77cadd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ SINGLE “USER CONFIG” CELL\n",
+    "CONFIG_PATH = \"/content/drive/MyDrive/boan_data/env.json\"  # path to config JSON on Drive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42300cbf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ STEP 0 · SETUP\n",
+    "!pip install -q pdfplumber layoutparser[layoutmodels] sentence-transformers faiss-cpu\n",
+    "from google.colab import drive\n",
+    "import os, json\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "drive.mount('/content/drive')\n",
+    "with open(CONFIG_PATH) as f:\n",
+    "    cfg = json.load(f)\n",
+    "SERVICE_KEY = cfg['SERVICE_KEY']\n",
+    "DCLSF_CD = cfg.get('DCLSF_CD', 'A00')\n",
+    "START_DATE = cfg.get('START_DATE', '2020-01-01')\n",
+    "END_DATE = cfg.get('END_DATE', '2025-07-08')\n",
+    "PAGE_SIZE = cfg.get('PAGE_SIZE', 1000)\n",
+    "DRIVE_DIR = cfg.get('DRIVE_DIR', '/content/drive/MyDrive/boan_data')\n",
+    "HF_HOME_DIR = cfg.get('HF_HOME_DIR', '/content/drive/.hf_cache')\n",
+    "os.environ['HF_HOME'] = HF_HOME_DIR\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "785b1de2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests, json, os, sqlite3, faiss, torch, pdfplumber\n",
+    "import layoutparser as lp\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from tqdm import tqdm\n",
+    "import numpy as np\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc15af74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ STEP 1 · FETCH PDF LIST\n",
+    "def get_pdf_items():\n",
+    "    items=[]\n",
+    "    page=1\n",
+    "    while True:\n",
+    "        params={\n",
+    "            'serviceKey': SERVICE_KEY,\n",
+    "            'pageNo': page,\n",
+    "            'numOfRows': PAGE_SIZE,\n",
+    "            'dclsfCd': DCLSF_CD,\n",
+    "            'startDate': START_DATE,\n",
+    "            'endDate': END_DATE,\n",
+    "            'viewType': 'json'\n",
+    "        }\n",
+    "        url='https://apis.data.go.kr/1613000/genFldPriorInfoDsc/getGenFldList'\n",
+    "        r=requests.get(url,params=params)\n",
+    "        r.raise_for_status()\n",
+    "        data=r.json()\n",
+    "        cur=data.get('response',{}).get('body',{}).get('items',[])\n",
+    "        items.extend(cur)\n",
+    "        if len(cur)<PAGE_SIZE:\n",
+    "            break\n",
+    "        page+=1\n",
+    "    return items\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e238b861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ STEP 2 · PDF → STRUCTURED JSON\n",
+    "def pdf_to_paragraphs(pdf_url):\n",
+    "    local_path='/tmp/temp.pdf'\n",
+    "    with open(local_path,'wb') as f:\n",
+    "        f.write(requests.get(pdf_url).content)\n",
+    "    paragraphs=[]\n",
+    "    with pdfplumber.open(local_path) as pdf:\n",
+    "        for page_no,page in enumerate(pdf.pages,start=1):\n",
+    "            words=page.extract_words()\n",
+    "            layout=lp.PDFPageLayout.from_words(words)\n",
+    "            for block in layout:\n",
+    "                text=block.text\n",
+    "                if not text or len(text)<150:\n",
+    "                    continue\n",
+    "                paragraphs.append({'page':page_no,'text':text,'bbox':block.block.bbox})\n",
+    "    os.remove(local_path)\n",
+    "    return paragraphs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e7cc667",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ STEP 3 · EMBEDDING\n",
+    "model_name = 'upskyy/e5-large-korean' if torch.cuda.is_available() else 'BM-K/KoSimCSE-roberta-base'\n",
+    "model = SentenceTransformer(model_name)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34d55838",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ▶ STEP 4 · STORAGE\n",
+    "db=sqlite3.connect('docs.db')\n",
+    "cur=db.cursor()\n",
+    "cur.execute('CREATE TABLE IF NOT EXISTS docs (id INTEGER PRIMARY KEY, pdf_url TEXT, page INT, text TEXT, b0 REAL, b1 REAL, b2 REAL, b3 REAL)')\n",
+    "index=faiss.IndexFlatIP(1024)\n",
+    "items=get_pdf_items()\n",
+    "vecs_all=[]\n",
+    "for item in tqdm(items):\n",
+    "    paras=pdf_to_paragraphs(item['downloadUrl'])\n",
+    "    texts=[p['text'] for p in paras]\n",
+    "    if not texts:\n",
+    "        continue\n",
+    "    vecs=model.encode(texts,batch_size=32,convert_to_numpy=True)\n",
+    "    faiss.normalize_L2(vecs)\n",
+    "    vecs_all.append(vecs)\n",
+    "    for v,p in zip(vecs,paras):\n",
+    "        cur.execute('INSERT INTO docs (pdf_url, page, text, b0, b1, b2, b3) VALUES (?,?,?,?,?,?,?)',\n",
+    "                    (item['downloadUrl'], p['page'], p['text'], *p['bbox']))\n",
+    "    db.commit()\n",
+    "index.add(np.vstack(vecs_all))\n",
+    "faiss.write_index(index,'faiss_index.faiss')\n",
+    "import shutil\n",
+    "shutil.copy('docs.db',DRIVE_DIR)\n",
+    "shutil.copy('faiss_index.faiss',DRIVE_DIR)\n",
+    "print('docs and index saved to',DRIVE_DIR)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- allow notebook to load config from `env.json` on Google Drive
- document example configuration in `README`

## Testing
- `jq . bodo_pdf_colab.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_686e8df9100c8321971151858c9b2f71