### PR TITLE
Fix HF cache path and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@
   "END_DATE": "2025-07-08",
   "PAGE_SIZE": 1000,
   "DRIVE_DIR": "/content/drive/MyDrive/boan_data",
-  "HF_HOME_DIR": "/content/drive/.hf_cache"
+  "HF_HOME_DIR": "/content/hf_cache"
 }
 ```
 
 첫 번째 셀의 `CONFIG_PATH` 변수에 이 파일의 경로를 지정하면 나머지 값이 자동으로 불러와집니다.
+
+`HF_HOME_DIR`는 허깅페이스 모델 캐시 디렉터리입니다. 이 경로를 Google Drive에
+설정하면 캐시 생성 과정에서 "Operation not supported" 오류가 발생할 수 있으므로
+기본값으로 로컬 경로인 `/content/hf_cache`를 사용합니다. 캐시를 유지하고 싶다면
+작업 후 해당 폴더를 수동으로 Drive에 복사해 둘 수 있습니다.
 
 ## 자세한 사용 방법 (처음부터 끝까지)
 

--- a/bodo_pdf.py
+++ b/bodo_pdf.py
@@ -67,8 +67,9 @@ def main(config_path):
     end_date = cfg.get("END_DATE", "2025-07-08")
     page_size = int(cfg.get("PAGE_SIZE", 1000))
     drive_dir = cfg.get("DRIVE_DIR", "/content/drive/MyDrive/boan_data")
-    hf_home = cfg.get("HF_HOME_DIR", "/content/drive/.hf_cache")
+    hf_home = cfg.get("HF_HOME_DIR", "/content/hf_cache")
     os.makedirs(drive_dir, exist_ok=True)
+    os.makedirs(hf_home, exist_ok=True)
     os.environ["HF_HOME"] = hf_home
 
     model_name = "upskyy/e5-large-korean" if torch.cuda.is_available() else "snunlp/KR-SBERT-V40K-klueNLI-augSTS"

--- a/bodo_pdf_colab.ipynb
+++ b/bodo_pdf_colab.ipynb
@@ -42,7 +42,8 @@
     "END_DATE = cfg.get('END_DATE', '2025-07-08')\n",
     "PAGE_SIZE = cfg.get('PAGE_SIZE', 1000)\n",
     "DRIVE_DIR = cfg.get('DRIVE_DIR', '/content/drive/MyDrive/boan_data')\n",
-    "HF_HOME_DIR = cfg.get('HF_HOME_DIR', '/content/drive/.hf_cache')\n",
+    "HF_HOME_DIR = cfg.get('HF_HOME_DIR', '/content/hf_cache')\n",
+    "os.makedirs(HF_HOME_DIR, exist_ok=True)\n",
     "os.environ['HF_HOME'] = HF_HOME_DIR\n"
    ]
   },


### PR DESCRIPTION
## Summary
- change default `HF_HOME_DIR` to `/content/hf_cache`
- create HF cache directory before setting `HF_HOME`
- document Drive cache issues and optional manual copying

## Testing
- `python -m py_compile bodo_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_686ea76fd01c8321a84ff87b198e7f5e